### PR TITLE
Keep uploads folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 server/config/facebook.js
 server/config/foursquare.js
-server/uploads/*.jpg
+server/uploads/*
+!server/uploads/.gitkeep
 .DS_Store


### PR DESCRIPTION
Adds a .gitkeep file [blank] to uploads folder that is marked to NOT be ignored in .gitignore.
This allows us to keep an uploads folder without pushing any image files.
